### PR TITLE
Fix course lessons admin route and add lesson form

### DIFF
--- a/components/admin/courses/EditCourseModal.tsx
+++ b/components/admin/courses/EditCourseModal.tsx
@@ -128,6 +128,7 @@ const EditCourseModal: React.FC<EditCourseModalProps> = ({
 
         {activeTab === "lessons" && (
           <LessonsTab
+            course={courseData}
             lessons={lessons}
             isLoading={lessonsLoading}
             onSaveLesson={onSaveLesson}

--- a/components/admin/courses/EditLessonForm.tsx
+++ b/components/admin/courses/EditLessonForm.tsx
@@ -25,6 +25,7 @@ export const EditLessonForm: React.FC<EditLessonFormProps> = ({
       const [imagePreview, setImagePreview] = useState<string | null>(null);
       const [imageFile, setImageFile] = useState<File | null>(null);
       const [isImageDirty, setIsImageDirty] = useState(false);
+      const isExistingLesson = Boolean(lesson.id);
 
       const { addAlert } = useAlert();
     
@@ -109,7 +110,7 @@ export const EditLessonForm: React.FC<EditLessonFormProps> = ({
       <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
         <div className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">
-            Edit Lesson
+            {isExistingLesson ? "Edit Lesson" : "Add Lesson"}
           </h3>
 
           <input
@@ -124,6 +125,7 @@ export const EditLessonForm: React.FC<EditLessonFormProps> = ({
       />
 
           <div className="space-y-4">
+                  {isExistingLesson && (
                   <div className="flex items-center gap-6">
                     {(imagePreview || lesson?.lessonImg) && (
                       <div>
@@ -180,6 +182,7 @@ export const EditLessonForm: React.FC<EditLessonFormProps> = ({
                       </div>
                     )}
                   </div>
+                  )}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -289,7 +292,7 @@ export const EditLessonForm: React.FC<EditLessonFormProps> = ({
               className="px-4 py-2 border flex items-center rounded-md hover:bg-white bg-[#012657] text-white hover:cursor-pointer hover:text-[#012657]"
             >
               <Save size={16} className="mr-2" />
-              Save Changes
+              {isExistingLesson ? "Save Changes" : "Save Lesson"}
             </button>
           </div>
         </div>

--- a/components/admin/courses/LessonsTab.tsx
+++ b/components/admin/courses/LessonsTab.tsx
@@ -13,6 +13,7 @@ import { EditLessonForm } from "./EditLessonForm";
 import { Lesson } from "@/types/interfaces";
 
 interface LessonsTabProps {
+  course: Record<string, any>;
   lessons: Lesson[];
   isLoading: boolean;
   onSaveLesson: (lessonData: Lesson) => void;
@@ -20,6 +21,7 @@ interface LessonsTabProps {
 }
 
 export const LessonsTab: React.FC<LessonsTabProps> = ({
+  course,
   lessons,
   isLoading,
   onSaveLesson,
@@ -42,6 +44,21 @@ export const LessonsTab: React.FC<LessonsTabProps> = ({
     setEditingLesson({ ...lesson });
   };
 
+  const handleAddLesson = () => {
+    setEditingLesson({
+      title: "",
+      description: "",
+      orderNumber: lessons.length + 1,
+      contents: [],
+      headLineTag: "",
+      estimatedDuration: undefined,
+      outcomes: "",
+      objectives: "",
+      courseId: course?.id,
+      languageId: course?.languageId,
+    } as Lesson);
+  };
+
   const handleLessonChange = (field: keyof Lesson, value: any) => {
     if (editingLesson) {
       setEditingLesson((prev) => ({ ...prev!, [field]: value }));
@@ -60,9 +77,7 @@ export const LessonsTab: React.FC<LessonsTabProps> = ({
       <div className="flex justify-between items-center">
         <h3 className="text-lg font-semibold text-gray-900">Course Lessons</h3>
         <button
-          onClick={() => {
-            /* Add new lesson logic */
-          }}
+          onClick={handleAddLesson}
           className="px-4 hover:cursor-pointer py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 flex items-center"
         >
           <Plus size={16} className="mr-2" />

--- a/services/generalApi/lessons/api.ts
+++ b/services/generalApi/lessons/api.ts
@@ -140,7 +140,7 @@ export async function createLesson(lessonData: any) {
 
 export async function getCourseLessons(courseId: string) {
   const response = await axiosInstance.get(
-    `lessons/lessons/course-lessons/${courseId}`
+    `/lessons/lessons/course-lessons/${courseId}`
   );
   return response.data;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep the admin course lessons request on the backend-mounted `/lessons/lessons/course-lessons/:courseId` path
- wire the Lessons tab Add Lesson button to open the lesson form
- label the lesson form appropriately for new vs existing lessons

## Route investigation
- backend gateway mounts lesson-service at `/api/v1/lessons`
- lesson-service mounts `lessonRouter` at `/lessons`
- `lessonRouter` defines `GET /course-lessons/:courseId`
- final URL is `/api/v1/lessons/lessons/course-lessons/:courseId`

## Backend note
- A backend fix was prepared and committed in `Tech-Managers-at-Zabbot/zabbot-backend` on local branch `cursor/fix-course-lessons-a378`:
  - `cc17f80` Harden course lessons fetch
  - `5c8701e` Fix lesson content repository typing
- Pushing that repo failed with a 403 for `cursor[bot]` from this environment, so only the frontend PR could be published here.

## Testing
- `npm run build` (frontend) passes with existing warnings
- `npm run build` in `/tmp/zabbot-backend/lesson-service` passes after installing lesson-service dependencies
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a3bbca8-efce-4e0b-9bf0-380a0206a378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a3bbca8-efce-4e0b-9bf0-380a0206a378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

