### PR TITLE
Add AGENTS.md for Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Zabbot is a **Next.js 15 frontend-only** language learning web application (Yoruba and other languages). It communicates with a separate backend API (not in this repo) via `NEXT_PUBLIC_API_URL`.
+
+### Key commands
+
+| Action | Command |
+|--------|---------|
+| Install deps | `npm install` |
+| Dev server | `npm run dev` (uses Turbopack, reads `.env.development`) |
+| Build | `npm run build` |
+| Lint | `npm run lint` |
+
+### Environment
+
+- **Node.js v22** is required (the VM has it pre-installed).
+- A `.env.development` file must exist with at minimum `NEXT_PUBLIC_API_URL` set. Without this file, `npm run dev` will fail because the dev script uses `dotenv -e .env.development`.
+- The backend API is external; most data-dependent features (auth, lessons, leaderboard) will show errors without it.
+
+### Gotchas
+
+- **No automated tests exist** in this repository. There are no test files or test runner configured beyond `@types/jest` in devDependencies.
+- The dev script (`npm run dev`) uses `dotenv-cli` to load `.env.development` — if the file is missing, the command errors out immediately.
+- The `next.config.ts` allows images from `res.cloudinary.com` only; adding other image domains requires updating this config.
+- `npm run lint` is `next lint` and will succeed with warnings only (no errors in the current codebase).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for developing on this codebase.

### What's included

- Project overview (Next.js 15 frontend-only app)
- Key commands table (install, dev, build, lint)
- Environment setup notes (Node.js v22, `.env.development` requirements)
- Development gotchas (no tests exist, dotenv-cli dependency on `.env.development`, image domain config)

### Development environment verification

The following were verified during setup:

- **Lint**: `npm run lint` passes (warnings only, no errors)
- **Build**: `npm run build` compiles successfully (34 routes generated)
- **Dev server**: `npm run dev` starts on port 3000 with Turbopack
- **UI**: Homepage, signup, login, and terms pages all render correctly

[zabbot_app_demo.mp4](https://cursor.com/agents/bc-177fcdac-93b6-4cc4-8864-81ee3296fcd9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fzabbot_app_demo.mp4)

[Zabbot homepage](https://cursor.com/agents/bc-177fcdac-93b6-4cc4-8864-81ee3296fcd9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fzabbot_homepage.webp)
[Signup page](https://cursor.com/agents/bc-177fcdac-93b6-4cc4-8864-81ee3296fcd9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fzabbot_signup.webp)
[Login page](https://cursor.com/agents/bc-177fcdac-93b6-4cc4-8864-81ee3296fcd9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fzabbot_login.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-177fcdac-93b6-4cc4-8864-81ee3296fcd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-177fcdac-93b6-4cc4-8864-81ee3296fcd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

